### PR TITLE
Added BSD-2-Clause-Patent License.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD-2-Clause Plus Patent License
 
-Copyright (c) 2020, Greene Laboratory
+Copyright (c) 2020, Contributors & the Greene Laboratory at the University of Pennsylvania
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:
@@ -40,4 +40,3 @@ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVI
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
 IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-


### PR DESCRIPTION
Adding the new default license for GreeneLab (https://spdx.org/licenses/BSD-2-Clause-Patent) in text format (copied and paste from that link, and made some formatting).