### PR TITLE
GLS results in Pickle format are exported to RDS and tsv.gz

### DIFF
--- a/data/gls/gls_phenotypes-combined-phenomexcan.rds
+++ b/data/gls/gls_phenotypes-combined-phenomexcan.rds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a86756e843c984a7fbf39d5f29e3279c7efefe8677d7c19630e2cd6cfde3f57
+size 327274

--- a/data/gls/gls_phenotypes-combined-phenomexcan.tsv.gz
+++ b/data/gls/gls_phenotypes-combined-phenomexcan.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de6d44d563c65328f9eb88383ed303e6ece39358a061a6fffc54988d2a78b2e
+size 138610

--- a/nbs/12_gsa_gls/99-gls-export.ipynb
+++ b/nbs/12_gsa_gls/99-gls-export.ipynb
@@ -1,0 +1,1310 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "meaning-coupon",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009833,
+     "end_time": "2021-07-23T17:25:55.954498",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:55.944665",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "characteristic-elimination",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005707,
+     "end_time": "2021-07-23T17:25:55.966328",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:55.960621",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "This notebook exports results into other more accessible data formats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "variable-christopher",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006813,
+     "end_time": "2021-07-23T17:25:56.090647",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.083834",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "adolescent-female",
+   "metadata": {
+    "papermill": {
+     "duration": 0.778949,
+     "end_time": "2021-07-23T17:25:56.876453",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.097504",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import statsmodels.api as sm\n",
+    "from statsmodels.stats.multitest import multipletests\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.preprocessing import scale\n",
+    "import rpy2.robjects as ro\n",
+    "from rpy2.robjects import pandas2ri\n",
+    "from rpy2.robjects.conversion import localconverter\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "import conf\n",
+    "from gls import GLSPhenoplier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "gothic-federation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "readRDS = ro.r[\"readRDS\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "assured-auckland",
+   "metadata": {
+    "papermill": {
+     "duration": 0.049878,
+     "end_time": "2021-07-31T02:45:23.815403",
+     "exception": false,
+     "start_time": "2021-07-31T02:45:23.765525",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "saveRDS = ro.r[\"saveRDS\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "damaged-presentation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006703,
+     "end_time": "2021-07-23T17:25:56.890565",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.883862",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "residential-complaint",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019873,
+     "end_time": "2021-07-23T17:25:56.916952",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.897079",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/phenoplier/base/results/gls')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "OUTPUT_DIR = conf.RESULTS[\"GLS\"]\n",
+    "display(OUTPUT_DIR)\n",
+    "\n",
+    "assert OUTPUT_DIR.exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "indoor-barbados",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007055,
+     "end_time": "2021-07-23T17:25:56.931254",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.924199",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Get results files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "natural-dealer",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/phenoplier/base/results/gls/gls_phenotypes-combined-phenomexcan.pkl')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "input_filepath = OUTPUT_DIR / \"gls_phenotypes-combined-phenomexcan.pkl\"\n",
+    "display(input_filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "amateur-brief",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = pd.read_pickle(input_filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "yellow-advocate",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020631,
+     "end_time": "2021-07-23T17:25:56.958932",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.938301",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5782, 8)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "smaller-queens",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021133,
+     "end_time": "2021-07-23T17:25:56.987356",
+     "exception": false,
+     "start_time": "2021-07-23T17:25:56.966223",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>part_k</th>\n",
+       "      <th>cluster_id</th>\n",
+       "      <th>phenotype</th>\n",
+       "      <th>lv</th>\n",
+       "      <th>coef</th>\n",
+       "      <th>pvalue</th>\n",
+       "      <th>pvalue_twosided</th>\n",
+       "      <th>fdr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV246</td>\n",
+       "      <td>0.002401</td>\n",
+       "      <td>0.424213</td>\n",
+       "      <td>0.848425</td>\n",
+       "      <td>0.680765</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV607</td>\n",
+       "      <td>-0.006323</td>\n",
+       "      <td>0.691499</td>\n",
+       "      <td>0.617002</td>\n",
+       "      <td>0.873350</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV612</td>\n",
+       "      <td>-0.000822</td>\n",
+       "      <td>0.525786</td>\n",
+       "      <td>0.948428</td>\n",
+       "      <td>0.763843</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV74</td>\n",
+       "      <td>-0.006035</td>\n",
+       "      <td>0.685313</td>\n",
+       "      <td>0.629373</td>\n",
+       "      <td>0.870769</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV838</td>\n",
+       "      <td>0.024454</td>\n",
+       "      <td>0.023446</td>\n",
+       "      <td>0.046891</td>\n",
+       "      <td>0.087403</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   part_k  cluster_id          phenotype     lv      coef    pvalue  \\\n",
+       "0      29          22  100002_raw-Energy  LV246  0.002401  0.424213   \n",
+       "1      29          22  100002_raw-Energy  LV607 -0.006323  0.691499   \n",
+       "2      29          22  100002_raw-Energy  LV612 -0.000822  0.525786   \n",
+       "3      29          22  100002_raw-Energy   LV74 -0.006035  0.685313   \n",
+       "4      29          22  100002_raw-Energy  LV838  0.024454  0.023446   \n",
+       "\n",
+       "   pvalue_twosided       fdr  \n",
+       "0         0.848425  0.680765  \n",
+       "1         0.617002  0.873350  \n",
+       "2         0.948428  0.763843  \n",
+       "3         0.629373  0.870769  \n",
+       "4         0.046891  0.087403  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "applied-afghanistan",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert not data.isna().any().any()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mobile-prophet",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054372,
+     "end_time": "2021-07-31T02:50:02.974572",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:02.920200",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Save"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "married-rogers",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054372,
+     "end_time": "2021-07-31T02:50:02.974572",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:02.920200",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## RDS format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cardiac-association",
+   "metadata": {
+    "papermill": {
+     "duration": 0.067331,
+     "end_time": "2021-07-31T02:50:03.095641",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:03.028310",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/phenoplier/base/results/gls/gls_phenotypes-combined-phenomexcan.rds')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "output_file = input_filepath.with_suffix(\".rds\")\n",
+    "display(output_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "entire-hawaiian",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with localconverter(ro.default_converter + pandas2ri.converter):\n",
+    "    data_r = ro.conversion.py2rpy(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "armed-hearts",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <span>R/rpy2 DataFrame (5782 x 8)</span>\n",
+       "        <table>\n",
+       "          <thead>\n",
+       "            <tr>\n",
+       "              \n",
+       "              <th>part_k</th>\n",
+       "              \n",
+       "              <th>cluster_id</th>\n",
+       "              \n",
+       "              <th>phenotype</th>\n",
+       "              \n",
+       "              <th>...</th>\n",
+       "              \n",
+       "              <th>pvalue</th>\n",
+       "              \n",
+       "              <th>pvalue_twosided</th>\n",
+       "              \n",
+       "              <th>fdr</th>\n",
+       "              \n",
+       "            </tr>\n",
+       "          </thead>\n",
+       "          <tbody>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              22\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              '100002_r...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.424213\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.848425\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.680765\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              22\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              '100002_r...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.691499\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.617002\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.873350\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              22\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              '100002_r...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.525786\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.948428\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.763843\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              22\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              '100002_r...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.685313\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.629373\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.870769\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              ...\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              4\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              'reticulo...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000929\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.001858\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.006172\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              4\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              'reticulo...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.003248\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.006495\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.017371\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              4\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              'reticulo...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          <tr>\n",
+       "            \n",
+       "            <td>\n",
+       "              29\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              4\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              'reticulo...\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              \n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "            <td>\n",
+       "              0.000000\n",
+       "            </td>\n",
+       "            \n",
+       "          </tr>\n",
+       "          \n",
+       "          </tbody>\n",
+       "        </table>\n",
+       "    "
+      ],
+      "text/plain": [
+       "R object with classes: ('data.frame',) mapped to:\n",
+       "[Int..., Int..., Str..., Str..., Flo..., Flo..., Flo..., Flo...]\n",
+       "  part_k: <class 'rpy2.rinterface.IntSexpVector'>\n",
+       "  <rpy2.rinterface.IntSexpVector object at 0x7f40c8eaa900> [RTYPES.INTSXP]\n",
+       "  cluster_id: <class 'rpy2.rinterface.IntSexpVector'>\n",
+       "  <rpy2.rinterface.IntSexpVector object at 0x7f40c8eaa540> [RTYPES.INTSXP]\n",
+       "  phenotype: <class 'rpy2.rinterface_lib.sexp.StrSexpVector'>\n",
+       "  <rpy2.rinterface_lib.sexp.StrSexpVector object at 0x7f40c8eaa900> [RTYPES.STRSXP]\n",
+       "  lv: <class 'rpy2.rinterface_lib.sexp.StrSexpVector'>\n",
+       "  <rpy2.rinterface_lib.sexp.StrSexpVector object at 0x7f40c8eaa540> [RTYPES.STRSXP]\n",
+       "  coef: <class 'rpy2.rinterface.FloatSexpVector'>\n",
+       "  <rpy2.rinterface.FloatSexpVector object at 0x7f40c8eaa900> [RTYPES.REALSXP]\n",
+       "  pvalue: <class 'rpy2.rinterface.FloatSexpVector'>\n",
+       "  <rpy2.rinterface.FloatSexpVector object at 0x7f40c8ebf5c0> [RTYPES.REALSXP]\n",
+       "  pvalue_twosided: <class 'rpy2.rinterface.FloatSexpVector'>\n",
+       "  <rpy2.rinterface.FloatSexpVector object at 0x7f40c8eaa900> [RTYPES.REALSXP]\n",
+       "  fdr: <class 'rpy2.rinterface.FloatSexpVector'>\n",
+       "  <rpy2.rinterface.FloatSexpVector object at 0x7f40c8ebf5c0> [RTYPES.REALSXP]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "valuable-minister",
+   "metadata": {
+    "papermill": {
+     "duration": 0.109005,
+     "end_time": "2021-07-31T02:50:03.260979",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:03.151974",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rpy2.rinterface_lib.sexp.NULLType object at 0x7f407abf53c0> [RTYPES.NILSXP]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "saveRDS(data_r, str(output_file))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "behind-notice",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing: load the rds file again\n",
+    "data_r = readRDS(str(output_file))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "detailed-conspiracy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with localconverter(ro.default_converter + pandas2ri.converter):\n",
+    "    data_again = ro.conversion.rpy2py(data_r)\n",
+    "    data_again.index = data_again.index.astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "superior-transcription",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5782, 8)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_again.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "amateur-kingston",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>part_k</th>\n",
+       "      <th>cluster_id</th>\n",
+       "      <th>phenotype</th>\n",
+       "      <th>lv</th>\n",
+       "      <th>coef</th>\n",
+       "      <th>pvalue</th>\n",
+       "      <th>pvalue_twosided</th>\n",
+       "      <th>fdr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV246</td>\n",
+       "      <td>0.002401</td>\n",
+       "      <td>0.424213</td>\n",
+       "      <td>0.848425</td>\n",
+       "      <td>0.680765</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV607</td>\n",
+       "      <td>-0.006323</td>\n",
+       "      <td>0.691499</td>\n",
+       "      <td>0.617002</td>\n",
+       "      <td>0.873350</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV612</td>\n",
+       "      <td>-0.000822</td>\n",
+       "      <td>0.525786</td>\n",
+       "      <td>0.948428</td>\n",
+       "      <td>0.763843</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV74</td>\n",
+       "      <td>-0.006035</td>\n",
+       "      <td>0.685313</td>\n",
+       "      <td>0.629373</td>\n",
+       "      <td>0.870769</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>29</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV838</td>\n",
+       "      <td>0.024454</td>\n",
+       "      <td>0.023446</td>\n",
+       "      <td>0.046891</td>\n",
+       "      <td>0.087403</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   part_k  cluster_id          phenotype     lv      coef    pvalue  \\\n",
+       "0      29          22  100002_raw-Energy  LV246  0.002401  0.424213   \n",
+       "1      29          22  100002_raw-Energy  LV607 -0.006323  0.691499   \n",
+       "2      29          22  100002_raw-Energy  LV612 -0.000822  0.525786   \n",
+       "3      29          22  100002_raw-Energy   LV74 -0.006035  0.685313   \n",
+       "4      29          22  100002_raw-Energy  LV838  0.024454  0.023446   \n",
+       "\n",
+       "   pvalue_twosided       fdr  \n",
+       "0         0.848425  0.680765  \n",
+       "1         0.617002  0.873350  \n",
+       "2         0.948428  0.763843  \n",
+       "3         0.629373  0.870769  \n",
+       "4         0.046891  0.087403  "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_again.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "personalized-timing",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.testing.assert_frame_equal(\n",
+    "    data,\n",
+    "    data_again,\n",
+    "    check_dtype=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "statutory-tomato",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054704,
+     "end_time": "2021-07-31T02:50:03.492487",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:03.437783",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Text format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "progressive-literature",
+   "metadata": {
+    "papermill": {
+     "duration": 0.065359,
+     "end_time": "2021-07-31T02:50:03.611749",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:03.546390",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/miltondp/projects/labs/greenelab/phenoplier/base/results/gls/gls_phenotypes-combined-phenomexcan.tsv.gz')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# tsv format\n",
+    "output_file = input_filepath.with_suffix(\".tsv.gz\")\n",
+    "display(output_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "written-family",
+   "metadata": {
+    "papermill": {
+     "duration": 0.849908,
+     "end_time": "2021-07-31T02:50:04.516988",
+     "exception": false,
+     "start_time": "2021-07-31T02:50:03.667080",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data.to_csv(output_file, sep=\"\\t\", index=False, float_format=\"%.5e\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "hydraulic-reduction",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing\n",
+    "data2 = data.copy()\n",
+    "data2.index = list(range(0, data2.shape[0]))\n",
+    "\n",
+    "data_again = pd.read_csv(output_file, sep=\"\\t\")\n",
+    "\n",
+    "data_again.index = list(data_again.index)\n",
+    "data_again[\"part_k\"] = data_again[\"part_k\"].astype(float)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "precious-neighbor",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5782, 8)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_again.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "bronze-latitude",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>part_k</th>\n",
+       "      <th>cluster_id</th>\n",
+       "      <th>phenotype</th>\n",
+       "      <th>lv</th>\n",
+       "      <th>coef</th>\n",
+       "      <th>pvalue</th>\n",
+       "      <th>pvalue_twosided</th>\n",
+       "      <th>fdr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>29.0</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV246</td>\n",
+       "      <td>0.002401</td>\n",
+       "      <td>0.424213</td>\n",
+       "      <td>0.848425</td>\n",
+       "      <td>0.680765</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>29.0</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV607</td>\n",
+       "      <td>-0.006323</td>\n",
+       "      <td>0.691499</td>\n",
+       "      <td>0.617002</td>\n",
+       "      <td>0.873350</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>29.0</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV612</td>\n",
+       "      <td>-0.000822</td>\n",
+       "      <td>0.525786</td>\n",
+       "      <td>0.948428</td>\n",
+       "      <td>0.763843</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>29.0</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV74</td>\n",
+       "      <td>-0.006035</td>\n",
+       "      <td>0.685313</td>\n",
+       "      <td>0.629373</td>\n",
+       "      <td>0.870769</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>29.0</td>\n",
+       "      <td>22</td>\n",
+       "      <td>100002_raw-Energy</td>\n",
+       "      <td>LV838</td>\n",
+       "      <td>0.024454</td>\n",
+       "      <td>0.023446</td>\n",
+       "      <td>0.046891</td>\n",
+       "      <td>0.087403</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   part_k  cluster_id          phenotype     lv      coef    pvalue  \\\n",
+       "0    29.0          22  100002_raw-Energy  LV246  0.002401  0.424213   \n",
+       "1    29.0          22  100002_raw-Energy  LV607 -0.006323  0.691499   \n",
+       "2    29.0          22  100002_raw-Energy  LV612 -0.000822  0.525786   \n",
+       "3    29.0          22  100002_raw-Energy   LV74 -0.006035  0.685313   \n",
+       "4    29.0          22  100002_raw-Energy  LV838  0.024454  0.023446   \n",
+       "\n",
+       "   pvalue_twosided       fdr  \n",
+       "0         0.848425  0.680765  \n",
+       "1         0.617002  0.873350  \n",
+       "2         0.948428  0.763843  \n",
+       "3         0.629373  0.870769  \n",
+       "4         0.046891  0.087403  "
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_again.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "fleet-snake",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.testing.assert_frame_equal(\n",
+    "    data2,\n",
+    "    data_again,\n",
+    "    check_dtype=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "indoor-wilson",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "all,-execution,-papermill,-trusted",
+   "formats": "ipynb,py//py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 11.07736,
+   "end_time": "2021-07-23T17:26:06.055665",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "08_gsa_gls/50-gls-fdr.ipynb",
+   "output_path": "08_gsa_gls/50-gls-fdr.run.ipynb",
+   "parameters": {},
+   "start_time": "2021-07-23T17:25:54.978305",
+   "version": "2.2.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/12_gsa_gls/99-gls-export.ipynb
+++ b/nbs/12_gsa_gls/99-gls-export.ipynb
@@ -67,20 +67,12 @@
    },
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "import statsmodels.api as sm\n",
-    "from statsmodels.stats.multitest import multipletests\n",
-    "import numpy as np\n",
     "import pandas as pd\n",
-    "from sklearn.preprocessing import scale\n",
     "import rpy2.robjects as ro\n",
     "from rpy2.robjects import pandas2ri\n",
     "from rpy2.robjects.conversion import localconverter\n",
-    "from tqdm import tqdm\n",
     "\n",
-    "import conf\n",
-    "from gls import GLSPhenoplier"
+    "import conf"
    ]
   },
   {

--- a/nbs/12_gsa_gls/py/99-gls-export.py
+++ b/nbs/12_gsa_gls/py/99-gls-export.py
@@ -1,0 +1,152 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: all,-execution,-papermill,-trusted
+#     formats: ipynb,py//py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.7.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown] tags=[]
+# # Description
+
+# %% [markdown] tags=[]
+# This notebook exports results into other more accessible data formats.
+
+# %% [markdown] tags=[]
+# # Modules
+
+# %% tags=[]
+from pathlib import Path
+
+import statsmodels.api as sm
+from statsmodels.stats.multitest import multipletests
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import scale
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
+from rpy2.robjects.conversion import localconverter
+from tqdm import tqdm
+
+import conf
+from gls import GLSPhenoplier
+
+# %%
+readRDS = ro.r["readRDS"]
+
+# %% tags=[]
+saveRDS = ro.r["saveRDS"]
+
+# %% [markdown] tags=[]
+# # Settings
+
+# %% tags=[]
+OUTPUT_DIR = conf.RESULTS["GLS"]
+display(OUTPUT_DIR)
+
+assert OUTPUT_DIR.exists()
+
+# %% [markdown] tags=[]
+# # Get results files
+
+# %%
+input_filepath = OUTPUT_DIR / "gls_phenotypes-combined-phenomexcan.pkl"
+display(input_filepath)
+
+# %%
+data = pd.read_pickle(input_filepath)
+
+# %% tags=[]
+data.shape
+
+# %% tags=[]
+data.head()
+
+# %%
+assert not data.isna().any().any()
+
+# %% [markdown] tags=[]
+# # Save
+
+# %% [markdown] tags=[]
+# ## RDS format
+
+# %% tags=[]
+output_file = input_filepath.with_suffix(".rds")
+display(output_file)
+
+# %%
+with localconverter(ro.default_converter + pandas2ri.converter):
+    data_r = ro.conversion.py2rpy(data)
+
+# %%
+data_r
+
+# %% tags=[]
+saveRDS(data_r, str(output_file))
+
+# %%
+# testing: load the rds file again
+data_r = readRDS(str(output_file))
+
+# %%
+with localconverter(ro.default_converter + pandas2ri.converter):
+    data_again = ro.conversion.rpy2py(data_r)
+    data_again.index = data_again.index.astype(int)
+
+# %%
+data_again.shape
+
+# %%
+data_again.head()
+
+# %%
+pd.testing.assert_frame_equal(
+    data,
+    data_again,
+    check_dtype=False,
+)
+
+# %% [markdown] tags=[]
+# ## Text format
+
+# %% tags=[]
+# tsv format
+output_file = input_filepath.with_suffix(".tsv.gz")
+display(output_file)
+
+# %% tags=[]
+data.to_csv(output_file, sep="\t", index=False, float_format="%.5e")
+
+# %%
+# testing
+data2 = data.copy()
+data2.index = list(range(0, data2.shape[0]))
+
+data_again = pd.read_csv(output_file, sep="\t")
+
+data_again.index = list(data_again.index)
+data_again["part_k"] = data_again["part_k"].astype(float)
+
+# %%
+data_again.shape
+
+# %%
+data_again.head()
+
+# %%
+pd.testing.assert_frame_equal(
+    data2,
+    data_again,
+    check_dtype=False,
+)
+
+# %%

--- a/nbs/12_gsa_gls/py/99-gls-export.py
+++ b/nbs/12_gsa_gls/py/99-gls-export.py
@@ -24,20 +24,12 @@
 # # Modules
 
 # %% tags=[]
-from pathlib import Path
-
-import statsmodels.api as sm
-from statsmodels.stats.multitest import multipletests
-import numpy as np
 import pandas as pd
-from sklearn.preprocessing import scale
 import rpy2.robjects as ro
 from rpy2.robjects import pandas2ri
 from rpy2.robjects.conversion import localconverter
-from tqdm import tqdm
 
 import conf
-from gls import GLSPhenoplier
 
 # %%
 readRDS = ro.r["readRDS"]


### PR DESCRIPTION
This PR adds a notebook to convert the final GLS results (association between LV and a trait) from pickle format to RDS and `tsv.gz`.